### PR TITLE
Hide splash screen when Clerk has loaded

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,12 +5,17 @@ import useCachedResources from "./hooks/useCachedResources";
 import Navigation from "./navigation";
 import { ClerkProvider } from "@clerk/clerk-expo";
 import { tokenCache } from "./cache";
+import * as SplashScreen from "expo-splash-screen";
 
 // Your publishable Key goes here
 const publishableKey = "pk_XXXXXXXXXXXXXXXXXXX";
 
 export default function App() {
   const isLoadingComplete = useCachedResources();
+
+  React.useEffect(() => {
+    SplashScreen.preventAutoHideAsync();
+  }, []);
 
   if (!isLoadingComplete) {
     return null;

--- a/hooks/useCachedResources.ts
+++ b/hooks/useCachedResources.ts
@@ -1,6 +1,5 @@
 import { FontAwesome } from "@expo/vector-icons";
 import * as Font from "expo-font";
-import * as SplashScreen from "expo-splash-screen";
 import * as React from "react";
 
 export default function useCachedResources() {
@@ -10,8 +9,6 @@ export default function useCachedResources() {
   React.useEffect(() => {
     async function loadResourcesAndDataAsync() {
       try {
-        SplashScreen.preventAutoHideAsync();
-
         // Load fonts
         await Font.loadAsync({
           ...FontAwesome.font,
@@ -22,7 +19,6 @@ export default function useCachedResources() {
         console.warn(e);
       } finally {
         setLoadingComplete(true);
-        SplashScreen.hideAsync();
       }
     }
 

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -14,6 +14,7 @@ import MyProfileScreen from "../screens/MyProfileScreen";
 import { RootStackParamList } from "../types";
 import LinkingConfiguration from "./LinkingConfiguration";
 import { ClerkLoaded, useUser } from "@clerk/clerk-expo";
+import * as SplashScreen from "expo-splash-screen";
 
 export default function Navigation() {
   return (
@@ -31,7 +32,13 @@ const Stack = createNativeStackNavigator<RootStackParamList>();
  * https://reactnavigation.org/docs/auth-flow
  */
 const RootNavigator = () => {
-  const { isSignedIn } = useUser();
+  const { isSignedIn, isLoaded } = useUser();
+  
+  React.useEffect(() => {
+    if (isLoaded) {
+      SplashScreen.hideAsync();
+    }
+  }, [isLoaded]);
 
   return (
     <ClerkLoaded>


### PR DESCRIPTION
This approach hides the app's Splash Screen after Clerk has loaded its state.

Currently, we hide it when the fonts have loaded and this causes a flicker sometimes.